### PR TITLE
Set the logger field in the StatsCollector

### DIFF
--- a/stats_collector.go
+++ b/stats_collector.go
@@ -42,6 +42,7 @@ func NewStatsCollector(writer api.Writer, interval time.Duration, logger logrus.
 	collector := &StatsCollector{
 		writer:          writer,
 		interval:        interval,
+		logger:          logger,
 		powerOnSuccess:  make(map[string]int64),
 		powerOnFailure:  make(map[string]int64),
 		powerOffSuccess: make(map[string]int64),


### PR DESCRIPTION
This fixes a panic when `writeToCollectd()` is called with logger being nil.
