### PR TITLE
main: set base vm path on event listener

### DIFF
--- a/cmd/collectd-vsphere/main.go
+++ b/cmd/collectd-vsphere/main.go
@@ -127,6 +127,7 @@ func mainAction(c *cli.Context) error {
 		URL:         u,
 		Insecure:    c.Bool("vsphere-insecure"),
 		ClusterPath: c.String("vsphere-cluster"),
+		BaseVMPath:  c.String("vsphere-base-vm-folder"),
 	}, statsCollector)
 
 	panicErr, _ := raven.CapturePanic(func() {


### PR DESCRIPTION
We added a CLI setting for this, but forgot to pass it to the event listener.
