### PR TITLE
Dockerize collectd-vsphere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+vendor
+!vendor/manifest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: go
-go: 1.7.5
-sudo: false
+go: 1.11.x
+
 install:
 - make prereqs
 - make deps
+
 script:
 - make test
 - make copyright
 - git diff --exit-code
 - git diff --cached --exit-code
 - make crossbuild
+- make docker-build
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
@@ -18,6 +20,16 @@ env:
   global:
   - 'TRAVIS_COMMIT_SHORT="${TRAVIS_COMMIT:0:7}"'
   - 'GOBUILDFLAGS="-x"'
+
+deploy:
+  provider: script
+  script: bin/docker-push
+  # we don't need this for docker, but the artifacts push does
+  skip_cleanup: true
+  on:
+    # push all non-PR builds to Docker Hub
+    all_branches: true
+    condition: "$TRAVIS_PULL_REQUEST == false"
 
 addons:
   artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build collectd-vsphere in a separate container
+FROM golang:1.11 AS builder
+
+RUN go get github.com/FiloSottile/gvt
+
+WORKDIR /go/src/github.com/travis-ci/collectd-vsphere
+
+COPY . .
+RUN make deps
+ENV CGO_ENABLED 0
+RUN make build
+
+
+
+FROM ubuntu:xenial
+
+RUN apt-get update -yqq && apt-get install -y ca-certificates && update-ca-certificates
+RUN apt-get install -y debian-archive-keyring apt-transport-https curl
+
+COPY librato-collectd-pin /etc/apt/preferences.d/librato-collectd
+RUN echo "deb https://packagecloud.io/librato/librato-collectd/ubuntu/ xenial main" > /etc/apt/sources.list.d/librato_librato-collectd.list
+RUN curl -L https://packagecloud.io/librato/librato-collectd/gpgkey 2>/dev/null | apt-key add -
+
+RUN apt-get update -yqq && apt-get install -y collectd liboping0 snmp snmp-mibs-downloader
+
+COPY --from=builder /go/bin/collectd-vsphere .
+COPY docker-run.sh .
+CMD ["./docker-run.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2017 Travis CI GmbH
+Copyright © 2019 Travis CI GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ GENERATED_VAR := main.GeneratedString
 GENERATED_VALUE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%S%z')
 COPYRIGHT_VAR := main.CopyrightString
 COPYRIGHT_VALUE ?= $(shell grep -i ^copyright LICENSE | sed 's/^[Cc]opyright //')
+DOCKER_IMAGE_REPO ?= travisci/collectd-vsphere
+DOCKER_DEST ?= $(DOCKER_IMAGE_REPO):$(VERSION_VALUE)
 
+DOCKER ?= docker
 GOPATH := $(shell echo $${GOPATH%%:*})
 GOBUILD_LDFLAGS ?= \
     -X '$(VERSION_VAR)=$(VERSION_VALUE)' \
@@ -47,6 +50,10 @@ crossbuild: deps
 		-ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
 	GOARCH=amd64 GOOS=linux go build $(GOBUILDFLAGS) -o build/linux/amd64/collectd-vsphere \
 		-ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
+
+.PHONY: docker-build
+docker-build:
+	$(DOCKER) build -t $(DOCKER_DEST) .
 
 .PHONY: distclean
 distclean:

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push travisci/collectd-vsphere

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+main() {
+  /opt/collectd/sbin/collectdmon -c /opt/collectd/sbin/collectd
+  ./collectd-vsphere
+}
+
+write_collectd_config() {
+  local conf=/opt/collectd/etc/collectd.conf
+  cat <<EOF >$conf
+# Set by Librato
+Interval 60
+
+LoadPlugin syslog
+<Plugin syslog>
+	LogLevel info
+</Plugin>
+
+LoadPlugin cpu
+LoadPlugin interface
+LoadPlugin load
+LoadPlugin memory
+LoadPlugin ping
+
+EOF
+
+  for host in $COLLECTD_VSPHERE_PING_AMQP_HOSTS; do
+    cat <<EOF >>$conf
+<Plugin ping>
+	Host "$host"
+	Interval 1.0
+	Timeout 0.9
+	MaxMissed 10
+</Plugin>
+
+EOF
+  done
+
+  for host in $COLLECTD_VSPHERE_PING_DNS_HOSTS; do
+    cat <<EOF >>$conf
+<Plugin ping>
+	Host "$host"
+	Interval 1.0
+	Timeout 0.9
+	MaxMissed -1
+</Plugin>
+
+EOF
+  done
+
+  cat <<EOF >>$conf
+Include "/opt/collectd/etc/collectd.conf.d/librato.conf"
+
+# REQUIRED for Cisco SNMP info
+LoadPlugin snmp
+Include "/opt/collectd/etc/collectd.conf.d/snmp.conf"
+
+LoadPlugin network
+<Plugin "network">
+  <Listen "127.0.0.1" "1785">
+    SecurityLevel "Encrypt"
+    AuthFile "/opt/collectd/etc/collectd-network-auth"
+  </Listen>
+</Plugin>
+EOF
+
+  conf=/opt/collectd/etc/collectd.conf.d/librato.conf
+  host=$(hostname)
+  cat <<EOF >$conf
+LoadPlugin write_http
+<Plugin write_http>
+  <Node "${host}">
+    URL "https://collectd.librato.com/v1/measurements"
+    Format "JSON"
+    BufferSize 8192
+    User "${COLLECTD_VSPHERE_LIBRATO_EMAIL}"
+    Password "${COLLECTD_VSPHERE_LIBRATO_TOKEN}"
+  </Node>
+</Plugin>
+EOF
+
+  conf=/opt/collectd/etc/collectd.conf.d/snmp.conf
+  cat <<EOF >$conf
+<Plugin snmp>
+	<Data "ifmib_if_octets64">
+		Type "if_octets"
+		Table true
+		Instance "IF-MIB::ifName"
+		Values "IF-MIB::ifHCInOctets" "IF-MIB::ifHCOutOctets"
+	</Data>
+
+	<Data "ifmib_if_packets64">
+		Type "if_packets"
+		Table true
+		Instance "IF-MIB::ifName"
+		Values "IF-MIB::ifHCInUcastPkts" "IF-MIB::ifHCOutUcastPkts"
+	</Data>
+
+  <Data "cpu_percentage">
+    Type "percent"
+    Table true
+    Instance "HOST-RESOURCES-MIB::hrDeviceDescr"
+    Values "HOST-RESOURCES-MIB::hrProcessorLoad"
+  </Data>
+
+	<Host "TravisCI-Prod-FW">
+		Address "${COLLECTD_VSPHERE_FW_IP}"
+		Version 2
+		Community "${COLLECTD_VSPHERE_FW_SNMP_COMMUNITY}"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64"
+		Interval 60
+	</Host>
+</Plugin>
+EOF
+
+  conf=/opt/collectd/etc/collectd-network-auth
+  echo "$COLLECTD_VSPHERE_COLLECTD_USERNAME: $COLLECTD_VSPHERE_COLLECTD_PASSWORD" >$conf
+}
+
+write_collectd_config
+main

--- a/librato-collectd-pin
+++ b/librato-collectd-pin
@@ -1,0 +1,3 @@
+Package: collectd collectd-core
+Pin: release l=librato-collectd
+Pin-Priority: 1001


### PR DESCRIPTION
This container runs collectd as well as the collectd-vsphere tool in one convenient package.

Instead of requiring you to mount config files into this container when you run it, the command for the container expects environment variables for its configuration, and before starting collectd, it will write out a collectd.conf and related files. This is specialized to the configuration we use for collectd, and makes it much easier to deploy this with secrets pulled from our keychains.